### PR TITLE
Add ShopSavvy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Popular collection of Homebridge Plugins
 
 - [Is It Down](https://github.com/sahilchaddha/homebridge-http-is-it-down/)
 - [People](https://github.com/PeteLawrence/homebridge-people)
+- [ShopSavvy](https://github.com/shopsavvy/homebridge-shopsavvy) - ContactSensor that triggers when a tracked product drops below your target price.
 - [Xiaomi BT Temperature Sensor](https://github.com/hannseman/homebridge-mi-hygrothermograph#readme)
 - [Weather API Temperature Sensor](https://github.com/werthdavid/homebridge-weather#readme)
 - [RPi CPU Temperature Sensor](https://github.com/YinHangCode/homebridge-raspberrypi-temperature)


### PR DESCRIPTION
Added [ShopSavvy](https://github.com/shopsavvy/homebridge-shopsavvy) to Sensors — a Homebridge plugin with ContactSensor that triggers when a tracked product drops below your target price.